### PR TITLE
Add qemu-arm-static when chroot on non-arm platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,7 @@ secret_csrf
 secret_key
 config.py
 
-# Generated images for the honeypots (big binary blobs)
+# Generated images for the honeypots (big binary blobs) and logs
 honeypot_images/*.img
+*output.txt
+*progress.txt

--- a/bin/create_image.sh
+++ b/bin/create_image.sh
@@ -68,7 +68,7 @@ cp -r "${DIR}/../../client" /mnt/tmp/usr/src/client >> "${LOG}" 2>&1
 echo "${3}" > /tmp/profile.json
 mv /tmp/profile.json /mnt/tmp/usr/src/client/honeypot_profile.json
 cp -r "${DIR}/../pipot/services" /mnt/tmp/usr/src/client/pipot >> "${LOG}" 2>&1
-cpuArch=$(python ${DIR}/getCpuArch.py)
+cpuArch=$(lscpu | grep Architecture | sed 's/Architecture:  *//')
 if [ $(arch) != arm* ]; then
     echo "This is not arm machine, copy QemuUserEmulation binary to the chroot"  >> "${LOG}" 2>&1
     # Copy QemuUserEmulation binary to the chroot

--- a/bin/getCpuArch.py
+++ b/bin/getCpuArch.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+import sys
+import subprocess
+import os
+
+
+def getArch():
+    info = subprocess.check_output(["lscpu"]).decode("utf-8")
+    # print(info)
+    arch = info.split('\n')[0].split()[1]
+    return arch
+
+
+if __name__ == "__main__":
+    sys.stdout.write("%s\n" % getArch())

--- a/install/install.sh
+++ b/install/install.sh
@@ -95,7 +95,7 @@ fi
 server_ip=`dig +short myip.opendns.com @resolver1.opendns.com`
 read -e -p "Server IP: " -i "${server_ip}" config_server_ip
 read -e -p "Server interface (SSL): " -i "443" config_server_port
-read -e -p "Application root (if not a whole (sub)domain, enter the path. None if whole (sub)domain): " -i "'/'" config_application_root
+read -e -p "Application root (if not a whole (sub)domain, enter the path. None if whole (sub)domain): " -i "None" config_application_root
 read -e -p "Instance name: " -i "PiPot Command & Control" config_instance_name
 read -e -p "Path to SSL certificate: " -i "/usr/src/pipot/server/cert/pipot.crt" config_ssl_cert
 read -e -p "Path to SSL key: " -i "/usr/src/pipot/server/cert/pipot.key" config_ssl_key

--- a/install/install.sh
+++ b/install/install.sh
@@ -95,7 +95,7 @@ fi
 server_ip=`dig +short myip.opendns.com @resolver1.opendns.com`
 read -e -p "Server IP: " -i "${server_ip}" config_server_ip
 read -e -p "Server interface (SSL): " -i "443" config_server_port
-read -e -p "Application root (if not a whole (sub)domain, enter the path. None if whole (sub)domain): " -i "None" config_application_root
+read -e -p "Application root (if not a whole (sub)domain, enter the path. None if whole (sub)domain): " -i "'/'" config_application_root
 read -e -p "Instance name: " -i "PiPot Command & Control" config_instance_name
 read -e -p "Path to SSL certificate: " -i "/usr/src/pipot/server/cert/pipot.crt" config_ssl_cert
 read -e -p "Path to SSL key: " -i "/usr/src/pipot/server/cert/pipot.key" config_ssl_key


### PR DESCRIPTION
The image boots on raspberry3B model while failed on raspberry3+B. 